### PR TITLE
Feature / Update actingAs and support union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ class StorePostTest extends TestCase
             // Fake sending the email
             ->fake(Mail::class)
             // Given is the post data, stored in a param called `post`
-            ->given([
+            ->given(fn (): array => [
                 'title' => 'My first post',
                 'content' => 'Lorem ipsum dolor amet sum it',
             ], 'post')
@@ -39,7 +39,7 @@ class StorePostTest extends TestCase
             ->given(fn(): Language => Language::current())
             // The $post and $language are automatically injected based on the results of the `given` methods
             ->when(fn (array $post, Language $language): TestResponse =>
-                return $this->postJson(route('api.posts.store'), $payload);
+                $this->postJson(route('api.posts.store'), $post)
             )
             // Instead of using a closure you can call a protected method as a callable with `(...)`
             ->then($this->responseContainsPostId(...))

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 /**
  * @method TestScenario fake(string $facade)
- * @method TestScenario as(Authenticatable $user, ?string $as = 'user', string $authProvider = TestScenario::DEFAULT_AUTH_PROVIDER)
+ * @method TestScenario as(Authenticatable $user, ?string $as = null)
  * @method TestScenario throws(string $exception, ?string $message = '')
  * @method TestScenario given(callable $condition, ?string $as = null)
  * @method TestScenario when(callable $action, ?string $as = null)

--- a/src/TestScenario.php
+++ b/src/TestScenario.php
@@ -61,7 +61,7 @@ class TestScenario
 
     public function as(
         Authenticatable $user,
-        ?string $injectAs = null,
+        ?string $injectAs = null
     ): TestScenario {
         if (! method_exists(static::$authProvider, 'actingAs')) {
             throw new \BadMethodCallException(sprintf(
@@ -71,7 +71,7 @@ class TestScenario
 
         // Pass on a closure as a given condition which execute the actingAs method on the auth provider
         return $this->given(
-            fn (): Authenticatable => call_user_func([static::$authProvider, 'actingAs'], $user),
+            fn (): Authenticatable => call_user_func([static::$authProvider, 'actingAs'], $user, [], static::$guard),
             $injectAs
         );
     }


### PR DESCRIPTION
### Ticket:
None

### Description:
- Updated actingAs by creating static method to set the auth provider and guard. Made the injectAs optional.
- Supported union types, first matching union type will be used
- [fix] Fixed readme example, which contained errors

### How to test:
- [x] Install plugin in a random project
- [x] Use the following methods in the setup method of your tests
```
TestScenario::setAuthProvider(TestScenario::SANCTUM_AUTH_PROVIDER); // Or TestScenario::PASSPORT_AUTH_PROVIDER
TestScenario::setGuard('api');
``` 
- [x] Use a union type in a given, when or then method
```
$this
  ->as(User::factory()->create)
  ->given(fn (Authenticable|User $user): array => []);
```
- [x] Assert that example is now correct